### PR TITLE
ci: fix syntax error in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 06:00
+      time: "06:00"
     labels:
       - maintenance
       - dependencies


### PR DESCRIPTION
Dependabot acted using the last valid config instead of the new because
of an error in the config. This error was only available by manual
inspection of this specific page:

https://github.com/jupyterhub/action-k8s-await-workloads/network/updates