### PR TITLE
ci: ensure workflows has the permissions to update branches/tags

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -16,6 +16,8 @@ jobs:
   local-action:
     name: Package to ./dist, commit, submit PR
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-updates.yaml
+++ b/.github/workflows/release-updates.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   actions-tagger:
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       # Action reference: https://github.com/Actions-R-Us/actions-tagger
       # NOTE: We pin a version not to have the source code (.ts files), but the

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,43 +50,43 @@ jobs:
         include:
           - job-name: "success: specific workload is healthy"
             input-workloads: deploy/healthy
-            input-timeout: 20
+            input-timeout: 30
             input-max-restarts: 0
             ci-workloads: healthy non-ready restarted pending
             ci-outcome: success
 
           - job-name: "success: tolerate one restart"
-            input-timeout: 20
+            input-timeout: 30
             input-max-restarts: 1
             ci-workloads: healthy restarted
             ci-outcome: success
 
           - job-name: "success: tolerate any restarts"
-            input-timeout: 20
+            input-timeout: 30
             ci-workloads: healthy restarted
             ci-outcome: success
 
           - job-name: "success: kube-system namespace"
             input-namespace: kube-system
-            input-timeout: 20
+            input-timeout: 30
             input-max-restarts: 0
             ci-workloads: non-ready
             ci-outcome: success
 
           - job-name: "failure: timeout, non-ready pod"
-            input-timeout: 20
+            input-timeout: 30
             input-max-restarts: 0
             ci-workloads: healthy non-ready
             ci-outcome: failure
 
           - job-name: "failure: timeout, pending pod"
-            input-timeout: 20
+            input-timeout: 30
             input-max-restarts: 0
             ci-workloads: healthy pending
             ci-outcome: failure
 
           - job-name: "failure: don't tolerate any restarts"
-            input-timeout: 20
+            input-timeout: 30
             input-max-restarts: 0
             ci-workloads: healthy restarted
             ci-outcome: failure


### PR DESCRIPTION
Based on jupyterhub/action-major-minor-tag-calculator#75, ensures we have the permissions required in our CI setup when we lower the permissions of GITHUB_TOKEN on an org level.

Also increased a timeout to reduce flakiness of tests.