### PR TITLE
Add changelog for 2.0.0

### DIFF
--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   k8s-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # GitHub Action reference: https://github.com/jupyterhub/action-k3s-helm
       - name: Setup k8s cluster
         uses: jupyterhub/action-k3s-helm@v3
         with:
-          k3s-channel: v1.23 # https://update.k3s.io/v1-release/channels
+          k3s-channel: v1.25 # https://update.k3s.io/v1-release/channels
           metrics-enabled: false
           traefik-enabled: false
 
@@ -23,16 +23,16 @@ jobs:
           helm install jupyterhub jupyterhub \
               --repo https://jupyterhub.github.io/helm-chart/
 
-      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-await-workloads
+      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-await-workloads#readme
       - name: Await jupyterhub
-        uses: jupyterhub/action-k8s-await-workloads@v1
+        uses: jupyterhub/action-k8s-await-workloads@v2
         with:
           workloads: "" # all
           namespace: "" # default
           timeout: 60
           max-restarts: 0
 
-      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-namespace-report
+      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-namespace-report#readme
       - name: Emit namespace report
         uses: jupyterhub/action-k8s-namespace-report@v1
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,57 @@
 # Changelog
 
-## [1.0]
+## 1.0
 
-### [1.0.0] - UNRELEASED
+### v2.0.0 - 2022-12-29
+
+([full changelog](https://github.com/jupyterhub/action-k8s-await-workloads/compare/v1.0.0...v2.0.0))
+
+#### Breaking changes
+
+The action is now executed using Node 16.
+
+#### Maintenance and upkeep improvements
+
+- Update to node16 [#60](https://github.com/jupyterhub/action-k8s-await-workloads/pull/60) ([@manics](https://github.com/manics))
+- Release: update ./dist and package-lock.json [#58](https://github.com/jupyterhub/action-k8s-await-workloads/pull/58) ([@github-actions](https://github.com/github-actions))
+- build(deps): bump @actions/core from 1.9.1 to 1.10.0 [#52](https://github.com/jupyterhub/action-k8s-await-workloads/pull/52) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/core from 1.9.0 to 1.9.1 [#51](https://github.com/jupyterhub/action-k8s-await-workloads/pull/51) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/core from 1.8.2 to 1.9.0 [#49](https://github.com/jupyterhub/action-k8s-await-workloads/pull/49) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/core from 1.8.0 to 1.8.2 [#44](https://github.com/jupyterhub/action-k8s-await-workloads/pull/44) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/core from 1.6.0 to 1.8.0 [#43](https://github.com/jupyterhub/action-k8s-await-workloads/pull/43) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/exec from 1.1.0 to 1.1.1 [#41](https://github.com/jupyterhub/action-k8s-await-workloads/pull/41) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/core from 1.4.0 to 1.6.0 [#37](https://github.com/jupyterhub/action-k8s-await-workloads/pull/37) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/core from 1.3.0 to 1.4.0 [#33](https://github.com/jupyterhub/action-k8s-await-workloads/pull/33) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/exec from 1.0.4 to 1.1.0 [#32](https://github.com/jupyterhub/action-k8s-await-workloads/pull/32) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump @actions/core from 1.2.6 to 1.3.0 [#31](https://github.com/jupyterhub/action-k8s-await-workloads/pull/31) ([@dependabot](https://github.com/dependabot))
+- Let v1,v2,etc reference tags instead of branches [#48](https://github.com/jupyterhub/action-k8s-await-workloads/pull/48) ([@consideRatio](https://github.com/consideRatio))
+- Relax dependabot config [#12](https://github.com/jupyterhub/action-k8s-await-workloads/pull/12) ([@consideRatio](https://github.com/consideRatio))
+- Release: update ./dist and package-lock.json [#10](https://github.com/jupyterhub/action-k8s-await-workloads/pull/10) ([@github-actions](https://github.com/github-actions))
+
+#### Documentation improvements
+
+- Fix README.md and action documentation [#34](https://github.com/jupyterhub/action-k8s-await-workloads/pull/34) ([@macobo](https://github.com/macobo))
+
+#### Continuous integration improvements
+
+- ci: fix permissions for pull request creation in package-to-dist workflow [#57](https://github.com/jupyterhub/action-k8s-await-workloads/pull/57) ([@consideRatio](https://github.com/consideRatio))
+- [pre-commit.ci] pre-commit autoupdate [#40](https://github.com/jupyterhub/action-k8s-await-workloads/pull/40) ([@pre-commit-ci](https://github.com/pre-commit-ci))
+- build(deps): bump Actions-R-Us/actions-tagger from 2.0.2 to 2.0.3 [#56](https://github.com/jupyterhub/action-k8s-await-workloads/pull/56) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump jupyterhub/action-k3s-helm from 2 to 3 [#50](https://github.com/jupyterhub/action-k8s-await-workloads/pull/50) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump actions/setup-python from 3 to 4 [#47](https://github.com/jupyterhub/action-k8s-await-workloads/pull/47) ([@dependabot](https://github.com/dependabot))
+- build(deps): bump Actions-R-Us/actions-tagger from 2.0.1 to 2.0.2 [#46](https://github.com/jupyterhub/action-k8s-await-workloads/pull/46) ([@dependabot](https://github.com/dependabot))
+- ci: update ./dist rebuild workflow to use node16 [#54](https://github.com/jupyterhub/action-k8s-await-workloads/pull/54) ([@consideRatio](https://github.com/consideRatio))
+- ci: dependabot for gha, update gha versions, fix intermittent issue in tests, replace deprecated action [#45](https://github.com/jupyterhub/action-k8s-await-workloads/pull/45) ([@consideRatio](https://github.com/consideRatio))
+- ci: ensure workflows has the permissions to update branches/tags [#30](https://github.com/jupyterhub/action-k8s-await-workloads/pull/30) ([@consideRatio](https://github.com/consideRatio))
+- ci: fix syntax error in dependabot.yml [#15](https://github.com/jupyterhub/action-k8s-await-workloads/pull/15) ([@consideRatio](https://github.com/consideRatio))
+- ci: increase timeout for slow image pulling [#13](https://github.com/jupyterhub/action-k8s-await-workloads/pull/13) ([@consideRatio](https://github.com/consideRatio))
+
+#### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/action-k8s-await-workloads/graphs/contributors?from=2021-01-31&to=2022-12-28&type=c))
+
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Faction-k8s-await-workloads+involves%3AconsideRatio+updated%3A2021-01-31..2022-12-28&type=Issues) | [@macobo](https://github.com/search?q=repo%3Ajupyterhub%2Faction-k8s-await-workloads+involves%3Amacobo+updated%3A2021-01-31..2022-12-28&type=Issues)
+
+### v1.0.0 - 2021-01-31
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ on:
 
 jobs:
   k8s-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # GitHub Action reference: https://github.com/jupyterhub/action-k3s-helm
       - name: Setup k8s cluster
-        uses: jupyterhub/action-k3s-helm@v2
+        uses: jupyterhub/action-k3s-helm@v3
         with:
-          k3s-channel: v1.23 # https://update.k3s.io/v1-release/channels
+          k3s-channel: v1.25 # https://update.k3s.io/v1-release/channels
           metrics-enabled: false
           traefik-enabled: false
 
@@ -53,16 +53,16 @@ jobs:
           helm install jupyterhub jupyterhub \
               --repo https://jupyterhub.github.io/helm-chart/
 
-      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-await-workloads
+      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-await-workloads#readme
       - name: Await jupyterhub
-        uses: jupyterhub/action-k8s-await-workloads@v1
+        uses: jupyterhub/action-k8s-await-workloads@v2
         with:
           workloads: "" # all
           namespace: "" # default
           timeout: 60
           max-restarts: 0
 
-      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-namespace-report
+      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-namespace-report#readme
       - name: Emit namespace report
         uses: jupyterhub/action-k8s-namespace-report@v1
         if: always()


### PR DESCRIPTION
I think this will result in closing #53, otherwise it will just make us use more updated node dependencies which seems fine as well. I did not bump any dependency a major version (none was around) so I think this will be fine to merge as a non-major release.