### PR TITLE
Update to node16

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
       # https://github.com/actions/setup-node
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: 16
 
       - name: Package to ./dist for test
         run: |

--- a/action.yaml
+++ b/action.yaml
@@ -37,5 +37,5 @@ inputs:
       Defaults to `0`. `-1` means infinite.
 
 runs:
-  using: "node12"
+  using: node16
   main: "dist/index.js"


### PR DESCRIPTION
Closes https://github.com/jupyterhub/action-k8s-await-workloads/issues/53

GitHub say this should be treated as a breaking change: https://github.blog/changelog/2022-05-20-actions-can-now-run-in-a-node-js-16-runtime/