### PR TITLE
Fix failure to transition to node20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,5 +37,5 @@ inputs:
       Defaults to `0`. `-1` means infinite.
 
 runs:
-  using: node16
+  using: node20
   main: "dist/index.js"


### PR DESCRIPTION
We were still getting node16 deprecated warnings, and I figured it relates to failing to update a line in the action.yml file.